### PR TITLE
v2.2

### DIFF
--- a/include/app/stopwatch.h
+++ b/include/app/stopwatch.h
@@ -1,0 +1,10 @@
+#include <views/framework.h>
+
+class AppShimStopwatch: public Composite {
+public:
+    AppShimStopwatch(Beeper *);
+    ~AppShimStopwatch();
+private:
+    class StopwatchMainScreen;
+    StopwatchMainScreen * appRoot;
+};

--- a/include/app/timer_editor.h
+++ b/include/app/timer_editor.h
@@ -5,7 +5,7 @@
 #include <app/proto/navigation_stack.h>
 #include <sound/sequencer.h>
 
-class AppShimTimerEditor: public ProtoShimNavigationStack, DroppingDigits {
+class AppShimTimerEditor: public ProtoShimNavigationStack {
 public:
     AppShimTimerEditor(Beeper *);
     ~AppShimTimerEditor();

--- a/include/app/weighing.h
+++ b/include/app/weighing.h
@@ -24,6 +24,7 @@ private:
         WAIT_CONNECT,
         WEIGHING
     };
+    WeighingAppState curState;
     void update_state(transition_type_t);
 };
 #endif

--- a/include/devices/big_clock.h
+++ b/include/devices/big_clock.h
@@ -12,7 +12,7 @@
 
 // Plasma Information System OS (not DOS, there's no disk in it!)
 #define PRODUCT_NAME "PIS-OS"
-#define PRODUCT_VERSION "2.1"
+#define PRODUCT_VERSION "2.2"
 
 // ---- Connection to DISP BOARD ----
 const gpio_num_t HWCONF_PLASMA_DATABUS_GPIOS[] = {

--- a/include/devices/smol_clock.h
+++ b/include/devices/smol_clock.h
@@ -9,7 +9,7 @@
 
 // Plasma Information System OS (not DOS, there's no disk in it!)
 #define PRODUCT_NAME "microPIS-OS"
-#define PRODUCT_VERSION "2.1"
+#define PRODUCT_VERSION "2.2"
 
 // ---- Connection to beeper ----
 const gpio_num_t HWCONF_BEEPER_GPIO = GPIO_NUM_12;

--- a/include/service/balance_board.h
+++ b/include/service/balance_board.h
@@ -14,4 +14,5 @@ void balance_board_start(SensorPool*);
 void balance_board_scan(bool);
 balance_board_state_t balance_board_state();
 void balance_board_zero();
+void balance_board_led(bool);
 #endif

--- a/include/service/time.h
+++ b/include/service/time.h
@@ -21,6 +21,11 @@ typedef struct tk_date {
     int dayOfWeek;
 } tk_date_t;
 
+typedef struct tk_datetime {
+    tk_date_t date;
+    tk_time_of_day_t time;
+} tk_datetime_t;
+
 /// @brief Start up the timekeeping service
 void timekeeping_begin();
 
@@ -34,8 +39,10 @@ tk_date_t get_current_date();
 void set_current_time(tk_time_of_day_t);
 /// @brief Set the current date without changing the timezone et al
 void set_current_date(tk_date_t);
+/// @brief Returns the system uptime as human-readable components
+tk_datetime_t get_uptime();
 
-tk_time_of_day operator -(const tk_time_of_day_t& a, const tk_time_of_day_t& b);
+tk_time_of_day_t operator -(const tk_time_of_day_t& a, const tk_time_of_day_t& b);
 bool operator==(const tk_time_of_day_t& a, const tk_time_of_day_t& b);
 bool operator<(const tk_time_of_day_t& a, const tk_time_of_day_t& b);
 bool operator<=(const tk_time_of_day_t& a, const tk_time_of_day_t& b);

--- a/include/service/time.h
+++ b/include/service/time.h
@@ -21,11 +21,6 @@ typedef struct tk_date {
     int dayOfWeek;
 } tk_date_t;
 
-typedef struct tk_datetime {
-    tk_date_t date;
-    tk_time_of_day_t time;
-} tk_datetime_t;
-
 /// @brief Start up the timekeeping service
 void timekeeping_begin();
 
@@ -40,7 +35,7 @@ void set_current_time(tk_time_of_day_t);
 /// @brief Set the current date without changing the timezone et al
 void set_current_date(tk_date_t);
 /// @brief Returns the system uptime as human-readable components
-tk_datetime_t get_uptime();
+tk_time_of_day_t get_uptime();
 
 tk_time_of_day_t operator -(const tk_time_of_day_t& a, const tk_time_of_day_t& b);
 bool operator==(const tk_time_of_day_t& a, const tk_time_of_day_t& b);

--- a/include/state.h
+++ b/include/state.h
@@ -8,6 +8,7 @@ typedef enum device_state {
     STATE_TIMER_EDITOR,
     STATE_IDLE,
     STATE_ALARMING,
+    STATE_STOPWATCH,
 #if HAS(BALANCE_BOARD_INTEGRATION)
     STATE_WEIGHING,
 #endif

--- a/include/views/common/dropping_digits.h
+++ b/include/views/common/dropping_digits.h
@@ -9,3 +9,81 @@ protected:
     void draw_dropping_digit(FantaManipulator *framebuffer, char current, char next, int phase, int left_offset);
     const font_definition_t * font;
 };
+
+class DroppingDigitView: public Composable, DroppingDigits {
+public:
+    int value;
+    DroppingDigitView(unsigned int digits, int initialValue, Beeper * b = nullptr):
+        DroppingDigits(),
+        value(initialValue),
+        digits(digits),
+        beeper(b),
+        disp_value { value },
+        phase { 0 },
+        dir { true } {
+            snprintf(fmt, 16, "%%0%dd", digits);
+            snprintf(buf_old, 16, fmt, disp_value);
+            snprintf(buf_new, 16, fmt, value);
+            width = digits * font->width;
+        }
+
+    void prepare() {
+        disp_value = value;
+        snprintf(buf_old, 16, fmt, value);
+        snprintf(buf_new, 16, fmt, disp_value);
+    }
+
+    void render(FantaManipulator *fb) {
+        if(phase > 0) {
+            if(dir) {
+                phase++;
+            } else {
+                phase--;
+            }
+            if(phase == 16 || phase == 0) {
+                phase = 0;
+                disp_value = value;
+                snprintf(buf_old, 16, fmt, disp_value);
+            }
+        }
+
+        int left_offset = 0;
+        for(int i = 0; i < digits; i++) {
+            draw_dropping_digit(fb, buf_old[i], buf_new[i], phase, left_offset);
+            left_offset += font->width;
+        }
+    }
+
+    void step() {
+        if(disp_value != value && phase == 0) {
+            if(disp_value - value == 1 || value - disp_value > 1) {
+                // scroll backward
+                phase = 16;
+                snprintf(buf_old, 16, fmt, value);
+                snprintf(buf_new, 16, fmt, disp_value);
+                dir = false;
+            } else  {
+                // scroll forward
+                phase = 1;
+                snprintf(buf_old, 16, fmt, disp_value);
+                snprintf(buf_new, 16, fmt, value);
+                dir = true;
+            }
+        }
+
+        if(phase == 8 && beeper) {
+            beeper->beep_blocking(CHANNEL_AMBIANCE, 100, 10);
+        }
+    }
+
+private:
+    char buf_old[16];
+    char buf_new[16];
+    char fmt[16];
+    int disp_value;
+    int digits;
+    int phase;
+    int wrapping_point;
+    bool dir;
+    Beeper * beeper;
+};

--- a/include/views/common/multiplexor.h
+++ b/include/views/common/multiplexor.h
@@ -7,7 +7,7 @@
 typedef uint16_t view_id_t;
 
 /// @brief Switches across multiple Renderables as desired
-class ViewMultiplexor: public Renderable {
+class ViewMultiplexor: public Composable {
 public: 
     ViewMultiplexor();
     ~ViewMultiplexor();

--- a/include/views/common/string_scroll.h
+++ b/include/views/common/string_scroll.h
@@ -7,6 +7,7 @@ public:
     StringScroll(const font_definition_t*, const char* string = nullptr);
     int string_width;
     bool scroll_only_if_not_fit;
+    bool stopped;
     bool align_to_right;
     bool start_at_visible;
     int holdoff;

--- a/include/views/common/string_scroll.h
+++ b/include/views/common/string_scroll.h
@@ -2,7 +2,7 @@
 #include <views/framework.h>
 
 /// @brief Scrolling string view
-class StringScroll: public Renderable {
+class StringScroll: public Composable {
 public:
     StringScroll(const font_definition_t*, const char* string = nullptr);
     int string_width;

--- a/include/views/idle_screens/next_alarm.h
+++ b/include/views/idle_screens/next_alarm.h
@@ -5,9 +5,10 @@
 #include <views/common/dropping_digits.h>
 
 /// @brief A view that shows the time remaining until the next alarm.
-class NextAlarmView: public Screen, DroppingDigits {
+class NextAlarmView: public Screen {
 public:
     NextAlarmView();
+    ~NextAlarmView();
     void prepare();
     void render(FantaManipulator*);
     void step();
@@ -18,9 +19,8 @@ private:
     tk_time_of_day_t time_remaining;
     bool show_alarm;
 
-    // For dropping digits
-    int disp_h, next_h, disp_m, next_m;
-    int phase;
-    const font_definition_t * font;
+    int disp_h, disp_m;
+    DroppingDigitView *hourView;
+    DroppingDigitView *minuteView;
 };
 

--- a/include/views/menu/date_setting.h
+++ b/include/views/menu/date_setting.h
@@ -4,7 +4,7 @@
 #include <fonts.h>
 #include <functional>
 
-class MenuDateSettingView: public Renderable, DroppingDigits {
+class MenuDateSettingView: public Composite {
 public:
     int year;
     int month;
@@ -14,17 +14,32 @@ public:
         year(initialYear),
         month(initialMonth),
         day(initialDay),
-        prevYear(initialYear),
-        prevMonth(initialMonth),
-        prevDay(initialDay),
-        animationPhase { -1 },
+        yearView(new DroppingDigitView(4, initialYear, b)),
+        monthView(new DroppingDigitView(2, initialMonth, b)),
+        dayView(new DroppingDigitView(2, initialDay, b)),
         cursorTimer { 0 },
         cursorPosition { YEAR },
         isShowingCursor { false },
         onFinish(onFinish),
-        beeper(b),
-        DroppingDigits() {}
+        beeper(b) {
+            int char_count = 10; // YYYY/MM/dd
+            int text_width = char_count * xnu_font.width;
+            int left_offset = HWCONF_DISPLAY_WIDTH_PX/2 - text_width/2;
 
+            yearView->x_offset = left_offset;
+            monthView->x_offset = yearView->x_offset + yearView->width + xnu_font.width;
+            dayView->x_offset = monthView->x_offset + monthView->width + xnu_font.width;
+
+            add_composable(yearView);
+            add_composable(monthView);
+            add_composable(dayView);
+        }
+
+    ~MenuDateSettingView() {
+        delete yearView, monthView, dayView;
+    }
+
+    void prepare();
     void step();
     void render(FantaManipulator *fb);
 
@@ -36,10 +51,9 @@ private:
         MONTH,
         DAY
     };
-    int prevYear;
-    int prevMonth;
-    int prevDay;
-    int animationPhase;
+    DroppingDigitView * yearView;
+    DroppingDigitView * monthView;
+    DroppingDigitView * dayView;
     uint8_t cursorTimer;
     DateCursorPosition cursorPosition;
     bool isShowingCursor;

--- a/include/views/menu/info_item.h
+++ b/include/views/menu/info_item.h
@@ -8,7 +8,7 @@ public:
     MenuInfoItemView(const char * title, const char * subtitle);
     ~MenuInfoItemView();
     
-private:
+protected:
     StringScroll * top_label;
     StringScroll * bottom_label;
 };

--- a/include/views/menu/time_setting.h
+++ b/include/views/menu/time_setting.h
@@ -5,7 +5,7 @@
 #include <fonts.h>
 #include <sound/beeper.h>
 
-class MenuTimeSettingView: public Renderable, DroppingDigits {
+class MenuTimeSettingView: public Composite {
 public:
     int hour;
     int minute;
@@ -15,18 +15,31 @@ public:
         hour(initialHour),
         minute(initialMinute),
         second(initialSeconds),
-        prevHour(initialHour),
-        prevMinute(initialMinute),
-        prevSecond(initialSeconds),
+        hourView(new DroppingDigitView(2, initialHour, b)),
+        minuteView(new DroppingDigitView(2, initialMinute, b)),
+        secondView(new DroppingDigitView(2, initialSeconds, b)),
         showSeconds(showSeconds),
-        animationPhase { -1 },
         cursorTimer { 0 },
         cursorPosition { CursorPosition::HOUR },
         isShowingCursor { false },
         onFinish(onFinish),
-        beeper(b),
-        DroppingDigits() {}
+        beeper(b) {
+            int char_count = showSeconds ? 8 : 5; // XX:XX:XX or XX:XX
+            int text_width = char_count * xnu_font.width;
+            int left_offset = HWCONF_DISPLAY_WIDTH_PX/2 - text_width/2;
 
+            hourView->x_offset = left_offset;
+            minuteView->x_offset = hourView->x_offset + hourView->width + xnu_font.width;
+            secondView->x_offset = minuteView->x_offset + minuteView->width + xnu_font.width;
+
+            add_composable(hourView);
+            add_composable(minuteView);
+            if(showSeconds) {
+                add_composable(secondView);
+            }
+        }
+
+    void prepare();
     void step();
     void render(FantaManipulator *fb);
 
@@ -38,11 +51,10 @@ private:
         MINUTE,
         SECOND
     };
+    DroppingDigitView * hourView;
+    DroppingDigitView * minuteView;
+    DroppingDigitView * secondView;
     bool showSeconds;
-    int prevHour;
-    int prevMinute;
-    int prevSecond;
-    int animationPhase;
     uint8_t cursorTimer;
     CursorPosition cursorPosition;
     bool isShowingCursor;

--- a/src/app/alarm_editor.cpp
+++ b/src/app/alarm_editor.cpp
@@ -77,7 +77,7 @@ public:
         framecount { 0 },
         cursorShows { true },
         onActivated(onActivated) {
-            add_subrenderable(label);
+            add_composable(label);
         }
     
     ~AlarmDaySelectorView() {

--- a/src/app/alarm_editor.cpp
+++ b/src/app/alarm_editor.cpp
@@ -74,6 +74,8 @@ public:
         label(new StringScroll(&keyrus0808_font, title)),
         setting(setting),
         cursor { 0 },
+        framecount { 0 },
+        cursorShows { true },
         onActivated(onActivated) {
             add_subrenderable(label);
         }

--- a/src/app/menu.cpp
+++ b/src/app/menu.cpp
@@ -6,6 +6,23 @@
 #include <rsrc/common_icons.h>
 #include <service/time.h>
 
+class UptimeView: public MenuInfoItemView {
+public:
+    UptimeView(): MenuInfoItemView("Uptime", "") {
+        bottom_label->stopped = true;
+    }
+
+    void step() {
+        tk_datetime_t uptime = get_uptime();
+        snprintf(buf, 16, "%dd %dh%dm%ds", uptime.date.day, uptime.time.hour, uptime.time.minute, uptime.time.second, uptime.time.millisecond);
+        bottom_label->set_string(buf);
+        MenuInfoItemView::step();
+    }
+
+private:
+    char buf[16];
+};
+
 AppShimMenu::AppShimMenu(Beeper *b): ProtoShimNavMenu::ProtoShimNavMenu() {
     beeper = b;
     std::function<void(bool, Renderable*)> normalActivationFunction = [this](bool isActive, Renderable* instance) {
@@ -103,6 +120,7 @@ AppShimMenu::AppShimMenu(Beeper *b): ProtoShimNavMenu::ProtoShimNavMenu() {
     String tmp = NetworkManager::current_ip();
     strncpy(buf_ip, tmp.c_str(), 16);
     system_info->add_view(new MenuInfoItemView("WiFi IP", buf_ip));
+    system_info->add_view(new UptimeView());
 
     static const uint8_t status_icns_data[] = {
         // By PiiXL

--- a/src/app/menu.cpp
+++ b/src/app/menu.cpp
@@ -13,8 +13,8 @@ public:
     }
 
     void step() {
-        tk_datetime_t uptime = get_uptime();
-        snprintf(buf, 16, "%dd %dh%dm%ds", uptime.date.day, uptime.time.hour, uptime.time.minute, uptime.time.second, uptime.time.millisecond);
+        tk_time_of_day_t uptime = get_uptime();
+        snprintf(buf, 16, "%d:%d:%d", uptime.hour, uptime.minute, uptime.second, uptime.millisecond);
         bottom_label->set_string(buf);
         MenuInfoItemView::step();
     }
@@ -60,7 +60,6 @@ AppShimMenu::AppShimMenu(Beeper *b): ProtoShimNavMenu::ProtoShimNavMenu() {
         tk_date_t today = get_current_date();
         if(ds_view != nullptr) delete ds_view;
         ds_view = new MenuDateSettingView(beeper, today.year, today.month, today.day, [this](int y, int m, int d) {
-            // todo: set date
             tk_date_t new_date = {
                 .year = y, .month = m, .day = d
             };
@@ -154,6 +153,14 @@ AppShimMenu::AppShimMenu(Beeper *b): ProtoShimNavMenu::ProtoShimNavMenu() {
 
     static const sprite_t wrench_icns = { .width = 16, .height = 16, .data = wrench_icns_data, .mask = nullptr };
 
+    static const uint8_t stopwatch_icns_data[] = {
+        // By PiiXL
+        0x07, 0xc0, 0x08, 0x20, 0x08, 0x20, 0x06, 0xc0, 0x00, 0x04, 0x37, 0xfa, 0x6c, 0x0c, 0xdb, 0x76, 
+	    0xd7, 0x7a, 0xd7, 0x7a, 0xd7, 0x0a, 0xd7, 0xfa, 0xd7, 0xfa, 0xdb, 0xf6, 0x6c, 0x0c, 0x37, 0xf8
+    };
+
+    static const sprite_t stopwatch_icns = { .width = 16, .height = 16, .data = stopwatch_icns_data, .mask = nullptr };
+
 #if HAS(BALANCE_BOARD_INTEGRATION)
     static const uint8_t weight_icns_data[] = {
         // By PiiXL
@@ -180,6 +187,7 @@ AppShimMenu::AppShimMenu(Beeper *b): ProtoShimNavMenu::ProtoShimNavMenu() {
 
     main_menu->add_view(new MenuActionItemView("Clock", [this](){ pop_state(STATE_MENU, TRANSITION_SLIDE_HORIZONTAL_LEFT); }, &clock_icns));
     main_menu->add_view(new MenuActionItemView("Timer", [this](){ push_state(STATE_TIMER_EDITOR, TRANSITION_SLIDE_HORIZONTAL_LEFT); }, &hourglass_icns));
+    main_menu->add_view(new MenuActionItemView("Stopwatch", [this](){ push_state(STATE_STOPWATCH, TRANSITION_SLIDE_HORIZONTAL_LEFT); }, &stopwatch_icns));
     main_menu->add_view(new MenuActionItemView("Alarm", [this](){ push_state(STATE_ALARM_EDITOR, TRANSITION_SLIDE_HORIZONTAL_LEFT); }, &alarm_icns));
 #if HAS(BALANCE_BOARD_INTEGRATION)
     main_menu->add_view(new MenuActionItemView("Weighing", [this](){ push_state(STATE_WEIGHING, TRANSITION_SLIDE_HORIZONTAL_LEFT); }, &weight_icns));

--- a/src/app/stopwatch.cpp
+++ b/src/app/stopwatch.cpp
@@ -1,0 +1,97 @@
+#include <app/stopwatch.h>
+#include <views/common/dropping_digits.h>
+#include <service/time.h>
+#include <input/keys.h>
+#include <state.h>
+
+class AppShimStopwatch::StopwatchMainScreen: public Composite {
+public:
+    StopwatchMainScreen(Beeper *b) {
+        hourView = new DroppingDigitView(2, 0);
+        minuteView = new DroppingDigitView(2, 0);
+        secondView = new DroppingDigitView(2, 0, b);
+        running = false;
+        start_time = { 0 };
+        stop_time = start_time;
+        strncpy(ms_buf, ".000", 8);
+
+        int char_count = 12; // XX:XX:XX.xxx
+        int text_width = 9 * xnu_font.width + 3 * keyrus0808_font.width;
+        int left_offset = HWCONF_DISPLAY_WIDTH_PX/2 - text_width/2;
+        hourView->x_offset = left_offset;
+        left_offset += hourView->width + xnu_font.width;
+        minuteView->x_offset = left_offset;
+        left_offset += hourView->width + xnu_font.width;
+        secondView->x_offset = left_offset;
+
+        add_composable(hourView);
+        add_composable(minuteView);
+        add_composable(secondView);
+    }
+
+    void render(FantaManipulator *fb) {
+        Composite::render(fb);
+        
+        fb->put_glyph(&xnu_font, ':', hourView->x_offset + hourView->width, 0);
+        fb->put_glyph(&xnu_font, ':', minuteView->x_offset + minuteView->width, 0);
+        fb->put_string(&keyrus0808_font, ms_buf, secondView->x_offset + secondView->width, fb->get_height() - keyrus0808_font.height - 1);
+    }
+
+    void step() {
+        Composite::step();
+
+        if(running) {
+            stop_time = get_uptime();
+        }
+
+        if(hid_test_key_any(KEY_HEADPAT | KEY_RIGHT) == KEYSTATE_HIT) {
+            running = !running;
+            if(start_time == stop_time && running) {
+                // We started from 0 rather than unpausing
+                start_time = get_uptime();
+                stop_time = get_uptime();
+            }
+        }
+        else if(hid_test_key_any(KEY_DOWN | KEY_UP) == KEYSTATE_HIT && !running) {
+            start_time = stop_time;
+        }
+        else if(hid_test_key_state(KEY_LEFT) == KEYSTATE_HIT) {
+            pop_state(STATE_STOPWATCH, TRANSITION_SLIDE_HORIZONTAL_RIGHT);
+        }
+
+        tk_time_of_day_t dt = stop_time - start_time;
+        if(dt.hour >= 100) {
+            start_time.hour += 100;
+            dt.hour -= 100;
+        }
+        hourView->value = dt.hour;
+        minuteView->value = dt.minute;
+        secondView->value = dt.second;
+
+        snprintf(ms_buf, 8, ".%03d", dt.millisecond % 1000);
+    }
+
+    ~StopwatchMainScreen() {
+        delete hourView;
+        delete minuteView;
+        delete secondView;
+    }
+
+private:
+    DroppingDigitView * hourView;
+    DroppingDigitView * minuteView;
+    DroppingDigitView * secondView;
+    bool running;
+    tk_time_of_day_t start_time;
+    tk_time_of_day_t stop_time;
+    char ms_buf[8];
+};
+
+AppShimStopwatch::AppShimStopwatch(Beeper *b) {
+    appRoot = new StopwatchMainScreen(b);
+    add_composable(appRoot);
+}
+
+AppShimStopwatch::~AppShimStopwatch() {
+    delete appRoot;
+}

--- a/src/app/weighing.cpp
+++ b/src/app/weighing.cpp
@@ -5,7 +5,7 @@
 
 #if HAS(BALANCE_BOARD_INTEGRATION)
 
-class AppShimWeighing::WeighingView: public Renderable {
+class AppShimWeighing::WeighingView: public Composable {
 public:
     WeighingView(SensorPool*s): 
         sensors(s),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@
 #include <app/menu.h>
 #include <app/alarm_editor.h>
 #include <app/timer_editor.h>
+#include <app/stopwatch.h>
 #include <app/weighing.h>
 #include <sensor/switchbot/meter.h>
 #include <views/overlays/fps_counter.h>
@@ -250,6 +251,7 @@ void setup() {
     appHost->add_view(new AppShimMenu(beepola), STATE_MENU);
     appHost->add_view(new AppShimAlarmEditor(beepola), STATE_ALARM_EDITOR);
     appHost->add_view(new AppShimTimerEditor(beepola), STATE_TIMER_EDITOR);
+    appHost->add_view(new AppShimStopwatch(beepola), STATE_STOPWATCH);
 #if HAS(BALANCE_BOARD_INTEGRATION)
     appHost->add_view(new AppShimWeighing(sensors), STATE_WEIGHING);
 #endif
@@ -266,8 +268,8 @@ static void print_memory() {
 #ifdef BOARD_HAS_PSRAM
         ESP_LOGI(LOG_TAG, "PSRAM: %d free of %d (%d minimum)", ESP.getFreePsram(), ESP.getPsramSize(), ESP.getMinFreePsram());
 #endif
-        tk_datetime_t uptime = get_uptime();
-        ESP_LOGI(LOG_TAG, "Uptime: %id %02dh%02dm%02ds%03dms", uptime.date.day, uptime.time.hour, uptime.time.minute, uptime.time.second, uptime.time.millisecond);
+        tk_time_of_day_t uptime = get_uptime();
+        ESP_LOGI(LOG_TAG, "Uptime: %02dh%02dm%02ds%03dms", uptime.hour, uptime.minute, uptime.second, uptime.millisecond);
         memory_last_print = now;
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -266,6 +266,8 @@ static void print_memory() {
 #ifdef BOARD_HAS_PSRAM
         ESP_LOGI(LOG_TAG, "PSRAM: %d free of %d (%d minimum)", ESP.getFreePsram(), ESP.getPsramSize(), ESP.getMinFreePsram());
 #endif
+        tk_datetime_t uptime = get_uptime();
+        ESP_LOGI(LOG_TAG, "Uptime: %id %02dh%02dm%02ds%03dms", uptime.date.day, uptime.time.hour, uptime.time.minute, uptime.time.second, uptime.time.millisecond);
         memory_last_print = now;
     }
 }

--- a/src/network/admin_panel.cpp
+++ b/src/network/admin_panel.cpp
@@ -129,7 +129,7 @@ static void render_alarms() {
         GP.TR();
          for(int d = 0; d < 7; d++) {
                 GP.TD();
-                GP.CHECK(tmp + days[d], ALARM_ON_DAY(a, 0));
+                GP.CHECK(tmp + days[d], ALARM_ON_DAY(a, d));
         }
         GP.TABLE_END();
         GP.BREAK();

--- a/src/service/time.cpp
+++ b/src/service/time.cpp
@@ -125,27 +125,18 @@ void set_current_date(tk_date_t date) {
     ESP_LOGI(LOG_TAG, "Changed date, current: %04d/%02d/%02d %02d:%02d:%02d", date.year, date.month, date.day, time.hour, time.minute, time.second);
 }
 
-tk_datetime_t get_uptime() {
+tk_time_of_day_t get_uptime() {
     int64_t uptime_us = esp_timer_get_time();
     int64_t uptime_ms = uptime_us / 1000;
     int64_t uptime_s = uptime_ms / 1000;
     int64_t uptime_m = uptime_s / 60;
     int64_t uptime_h = uptime_m / 60;
-    int64_t uptime_d = uptime_h / 24;
 
-    return tk_datetime_t {
-        .date = {
-            .year = 0,
-            .month = 0,
-            .day = (int) uptime_d,
-            .dayOfWeek = 0
-        },
-        .time = {
-            .hour = (int) uptime_h % 24,
-            .minute = (int) uptime_m % 60,
-            .second = (int) uptime_s % 60,
-            .millisecond = (int) uptime_ms % 1000
-        }
+    return {
+        .hour = (int) uptime_h,
+        .minute = (int) uptime_m % 60,
+        .second = (int) uptime_s % 60,
+        .millisecond = (int) uptime_ms % 1000
     };
 }
 

--- a/src/service/time.cpp
+++ b/src/service/time.cpp
@@ -125,6 +125,32 @@ void set_current_date(tk_date_t date) {
     ESP_LOGI(LOG_TAG, "Changed date, current: %04d/%02d/%02d %02d:%02d:%02d", date.year, date.month, date.day, time.hour, time.minute, time.second);
 }
 
+tk_datetime_t get_uptime() {
+    int64_t uptime_us = esp_timer_get_time();
+    int64_t uptime_ms = uptime_us / 1000;
+    int64_t uptime_s = uptime_ms / 1000;
+    int64_t uptime_m = uptime_s / 60;
+    int64_t uptime_h = uptime_m / 60;
+    int64_t uptime_d = uptime_h / 24;
+
+    return tk_datetime_t {
+        .date = {
+            .year = 0,
+            .month = 0,
+            .day = (int) uptime_d,
+            .dayOfWeek = 0
+        },
+        .time = {
+            .hour = (int) uptime_h % 24,
+            .minute = (int) uptime_m % 60,
+            .second = (int) uptime_s % 60,
+            .millisecond = (int) uptime_ms % 1000
+        }
+    };
+}
+
+// Why not std::chrono? idk, legacy I guess
+
 tk_time_of_day operator -(const tk_time_of_day_t& a, const tk_time_of_day_t& b) {
     tk_time_of_day result = { 0 };
 

--- a/src/views/common/dropping_digits.cpp
+++ b/src/views/common/dropping_digits.cpp
@@ -1,6 +1,6 @@
 #include <views/common/dropping_digits.h>
 
-
+// TODO: remove all those and rely only on the DroppingDigitView
 inline void itoa_padded(uint i, char * a) {
     a[0] = '0' + (i / 10);
     a[1] = '0' + (i % 10);

--- a/src/views/common/string_scroll.cpp
+++ b/src/views/common/string_scroll.cpp
@@ -1,7 +1,7 @@
 #include "views/common/string_scroll.h"
 #include <service/prefs.h>
 
-StringScroll::StringScroll(const font_definition_t * f, const char * s) {
+StringScroll::StringScroll(const font_definition_t * f, const char * s): Composable() {
     font = f;
     position = INT_MAX;
     string_width = 0;

--- a/src/views/common/string_scroll.cpp
+++ b/src/views/common/string_scroll.cpp
@@ -13,6 +13,7 @@ StringScroll::StringScroll(const font_definition_t * f, const char * s) {
     left_margin = 0;
     holdoff = 0;
     backing_buffer = nullptr;
+    stopped = false;
     set_string(s);
 
     switch(prefs_get_int(PREFS_KEY_DISP_SCROLL_SPEED)) {
@@ -87,8 +88,8 @@ int StringScroll::estimated_frame_count() {
 void StringScroll::render(FantaManipulator * fb) {
     if(backing_buffer == nullptr) return;
 
-    if(scroll_only_if_not_fit) {
-        if(string_width <= fb->get_width()) {
+    if(scroll_only_if_not_fit || stopped) {
+        if(string_width <= fb->get_width() || stopped) {
             fb->put_fanta(backing_buffer, align_to_right ? fb->get_width() - string_width : 0, y_position, backing_buffer_width, font->height);
             return;
         }

--- a/src/views/menu/action_item.cpp
+++ b/src/views/menu/action_item.cpp
@@ -5,14 +5,14 @@ MenuActionItemView::MenuActionItemView(const char * title, std::function<void()>
     label = new StringScroll((subtitle == nullptr) ? &keyrus0816_font : &keyrus0808_font, title);
     label->start_at_visible = true;
     label->holdoff = 240;
-    add_subrenderable(label);
+    add_composable(label);
     if(subtitle != nullptr) {
         sublabel = new StringScroll(&keyrus0808_font, subtitle);
         sublabel->set_y_position(keyrus0808_font.height);
         sublabel->align_to_right = true;
         sublabel->start_at_visible = true;
         sublabel->holdoff = 240;
-        add_subrenderable(sublabel);
+        add_composable(sublabel);
     } else {
         sublabel = nullptr;
     }

--- a/src/views/menu/info_item.cpp
+++ b/src/views/menu/info_item.cpp
@@ -13,8 +13,8 @@ MenuInfoItemView::MenuInfoItemView(const char * title, const char * subtitle) {
     bottom_label->holdoff = 100;
     bottom_label->align_to_right = true;
 
-    add_subrenderable(top_label);
-    add_subrenderable(bottom_label);
+    add_composable(top_label);
+    add_composable(bottom_label);
 }
 
 MenuInfoItemView::~MenuInfoItemView() {

--- a/src/views/menu/list_selection_item.cpp
+++ b/src/views/menu/list_selection_item.cpp
@@ -17,8 +17,8 @@ MenuListSelectorView::MenuListSelectorView(const char * title, std::vector<const
         value->left_margin = 10;
         label->start_at_visible = true;
         label->holdoff = 100;
-        add_subrenderable(label);
-        add_subrenderable(value);
+        add_composable(label);
+        add_composable(value);
 }
 
 MenuListSelectorView::~MenuListSelectorView() {

--- a/src/views/menu/number_selection_item.cpp
+++ b/src/views/menu/number_selection_item.cpp
@@ -19,8 +19,8 @@ MenuNumberSelectorView::MenuNumberSelectorView(const char * title, int min_, int
         value->holdoff = 100;
         label->start_at_visible = true;
         label->holdoff = 100;
-        add_subrenderable(label);
-        add_subrenderable(value);
+        add_composable(label);
+        add_composable(value);
         itoa(currentValue, currentValueStr, 10);
         value->set_string(currentValueStr);
     }


### PR DESCRIPTION
# Added
- Stopwatch app. Access from menu, Right to start/pause, Down/Up when paused to reset.
- Uptime display under Settings → Status.
- Periodic uptime and free RAM logging.

# Changed
- Weighing app now shows arrows when the weight has stabilized rather than when it is zero
- LED of Balance Board is now constantly on when Weighing app is launched, off otherwise
- Periodically blink the LED of Balance Board to keep it awake and connected (Yes you better wire-mod it unless you want to eat batteries like crazy)

# Fixed
- Don't furiously blink the LED of the Balance Board upon connection, which congested the Bluedroid queue and made the connection freeze
- Keep the Balance Board alive so that the connection does not get stuck over time and require a reboot of both the board and the clock
- `Composable` class allows to constrain a `Renderable` into a part of the screen "automagically". One step ahead to a proper composition engine with rects and all? 
- `DroppingDigitView` class allows to easily draw dropping digit numbers without direct calls to the `DroppingDigits` trait. (The trait currently remains for use-cases with non-standard easing curves, such as the clock view)