### PR TITLE
bump platform-espressif32 to latest ver 6.9.0 (Arduino - v2.0.17)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 build_flags = -DCORE_DEBUG_LEVEL=3 -DPDFB_PERF_LOGS -DPDFB_PERF_LOG_INTERVAL=1200 -DGP_NO_OTA -DGP_NO_DNS -DGP_NO_MDNS -D_IR_ENABLE_DEFAULT_=false -DDECODE_NEC=true -DDECODE_RC5=true -DDECODE_RC6=true -DDECODE_SONY=true
 
 [env]
-platform = espressif32@6.5.0
+platform = espressif32@6.9.0
 framework = arduino
 build_src_filter = +<*> -<.git/> -<.svn/> -<music/>
 board_build.partitions = partitions.csv


### PR DESCRIPTION
looks like it builds fine for all envs.
Any reason not to use the last officially supported Arduino platform with core 2.0.17?