### PR TITLE
platformio configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ captures/
 /data/music/wip*.pomf
 /data/music/WIP*.pomf
 /webroot/fvudata/*
+/local/

--- a/include/device_config.h
+++ b/include/device_config.h
@@ -28,7 +28,11 @@
 // #define HAS_BALANCE_BOARD_INTEGRATION
 
 // Enable the yukkuri voice talking clock
+#ifdef LIBAQUESTALK_FOUND
 #define HAS_AQUESTALK
+#else
+#warning "Lib AquesTalk not found, TTS disabled"
+#endif
 
 // Disable the faux brightness reduction for some UI elements by drawing them only every other frame
 // #define COMPOSABLE_NO_EVENODD

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,3 +1,8 @@
+[platformio]
+extra_configs =
+  local/pio_*.ini
+
+
 [common]
 build_flags = -Os -DCORE_DEBUG_LEVEL=3 -DPDFB_PERF_LOGS -DPDFB_PERF_LOG_INTERVAL=1200 -DGP_NO_OTA -DGP_NO_DNS -DGP_NO_MDNS -D_IR_ENABLE_DEFAULT_=false -DDECODE_NEC=true -DDECODE_RC5=true -DDECODE_RC6=true -DDECODE_SONY=true
 


### PR DESCRIPTION
allow disabling AQUESTALK/BT via build flags without hacking device_config
allow user to have it's own platformio configs