### PR TITLE
disable weather/wordnik by default if no API keys provided

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,12 +6,12 @@ ADMIN_LOGIN=\"plasma\"
 ADMIN_PASS=\"plasma\"
 
 # OpenWeatherMap configuration
-WEATHER_LAT=\"43.0642\" 
-WEATHER_LON=\"141.3469\"
-WEATHER_API_KEY=\"your_OpenWeatherMap_API_Key\"
+#WEATHER_LAT=\"43.0642\" 
+#WEATHER_LON=\"141.3469\"
+#WEATHER_API_KEY=\"your_OpenWeatherMap_API_Key\"
 
 # Wordnik configuration
-WORDNIK_API_KEY=\"your_Wordnik_API_key\"
+#WORDNIK_API_KEY=\"your_Wordnik_API_key\"
 
 # AquesTalk configuration
 AQUESTALK_LICENSE_KEY=\"XXX-XXX-XXX\"

--- a/src/service/owm/weather.cpp
+++ b/src/service/owm/weather.cpp
@@ -149,9 +149,14 @@ void weather_start() {
 
     firstRunSemaphore = xSemaphoreCreateBinary();
 
-    apiKey = prefs_get_string(PREFS_KEY_WEATHER_APIKEY, String(WEATHER_API_KEY));
-    latitude = prefs_get_string(PREFS_KEY_WEATHER_LAT, String(WEATHER_LAT));
-    longitude = prefs_get_string(PREFS_KEY_WEATHER_LON, String(WEATHER_LON));
+    apiKey = prefs_get_string(PREFS_KEY_WEATHER_APIKEY);
+    latitude = prefs_get_string(PREFS_KEY_WEATHER_LAT);
+    longitude = prefs_get_string(PREFS_KEY_WEATHER_LON);
+
+    if (!apiKey.length()){
+        ESP_LOGW(LOG_TAG, "No weather API key, disabling weather updates!");
+        return;
+    }
 
     int interval_minutes = prefs_get_int(PREFS_KEY_WEATHER_INTERVAL_MINUTES);
     if(interval_minutes == 0) {

--- a/src/service/wordnik.cpp
+++ b/src/service/wordnik.cpp
@@ -112,7 +112,12 @@ void wotd_start() {
     firstRunSemaphore = xSemaphoreCreateBinary();
     hasQueries = true;
 
-    apiKey = prefs_get_string(PREFS_KEY_WORDNIK_APIKEY, String(WORDNIK_API_KEY));
+    apiKey = prefs_get_string(PREFS_KEY_WORDNIK_APIKEY);
+
+    if (!apiKey.length()){
+        ESP_LOGW(LOG_TAG, "No wordnik API key, disabling updates!");
+        return;
+    }
 
     int interval_minutes = prefs_get_int(PREFS_KEY_WORDNIK_INTERVAL_MINUTES);
     if(interval_minutes == 0) {


### PR DESCRIPTION
if no API keys were provided on-build then disable updates on boot and do not hammer API servers with malformed requests